### PR TITLE
chg: etr: improve metadata rendering for generated articles

### DIFF
--- a/colusa/etr.py
+++ b/colusa/etr.py
@@ -222,12 +222,10 @@ class Render(object):
             if metadata:
                 time_published = extractor.get_published()
                 if time_published is not None:
-                    published_info = f'published on {time_published}'
+                    published_info = f' was published on {time_published}'
                 else:
                     published_info = ''
-                article_metadata = f"'''\n" \
-                                   f"source: {src_url} {published_info}\n\n{extractor.get_metadata()}\n" \
-                                   f"'''\n"
+                article_metadata = f"_(link:{src_url}[original article]{published_info})_\n\n{extractor.get_metadata()}\n"
                 file_out.write(article_metadata)
 
             file_out.write(content.value)


### PR DESCRIPTION
This PR is to improve rendering metadata of generated articles

**Previous**:
<img width="520" alt="prev" src="https://user-images.githubusercontent.com/1300689/129839554-5928fa59-0c0a-445b-8e43-179c2f8c44bf.png">

**Current**:
<img width="300" alt="current" src="https://user-images.githubusercontent.com/1300689/129839564-05a9b575-143e-4536-864d-33a4fb2ef7fe.png">

Pros:

* the generated article is render in cleaner way than previous one

Cons:

* article link is hidden
