### PR TITLE
feat: support rendering additional book properties

### DIFF
--- a/colusa/etr.py
+++ b/colusa/etr.py
@@ -282,6 +282,7 @@ pdf:
         - and include all generated asciidoc files from `urls`
         """
         included_files = '\n'.join(['include::%s[]' % x for x in self.file_list])
+        book_properties = '\n'.join([x.strip() for x in self.config.get('book_properties', [])])
         content = f'''= {self.config["title"]}
 {self.config["author"]}
 {self.config["version"]}
@@ -290,6 +291,7 @@ pdf:
 :toc:
 :imagesdir: images
 :homepage: {self.config["homepage"]}
+{book_properties}
 
 {included_files}
 '''


### PR DESCRIPTION
In the book configuration file, add new array `book_properties`
with content is list of strings. Those strings will be render as
book properties on master file (index.asciidoc)

Example:

```json
"book_properties": [
    "ifdef::backend-pdf[]",
    ":front-cover-image: image:cover.pdf[]",
    ":notitle:",
    "endif::[]",
    "ifdef::backend-epub3[]",
    ":front-cover-image: image:cover.png[]",
    "endif::[]"
]
```

Above example will instruct asciidoctor processor to use:
+ cover.pdf as front cover image when generating pdf
+ cover.png as front cover image when generating epub3