### PR TITLE
refactor(etr): Rework on Extractor

### DIFF
--- a/colusa/etr.py
+++ b/colusa/etr.py
@@ -72,10 +72,12 @@ class Extractor(object):
         self.published = None
         self.title = None
         self.extra_metadata = ''
-        self._parse_metadata()
+
         self.main_content = self._find_main_content()
         if self.main_content is None:
             raise ContentNotFoundError()
+
+        self._parse_metadata()
 
     def _parse_title(self) -> str:
         """
@@ -211,6 +213,8 @@ class Extractor(object):
         persons = {}
         author = None
         for g in graph:
+            if type(g) is not dict:
+                continue
             g_type = g.get('@type', '')
             if g_type == 'Article':
                 author = g.get('author', {}).get('@id')

--- a/colusa/plugins/etr_agilethought.py
+++ b/colusa/plugins/etr_agilethought.py
@@ -1,13 +1,15 @@
+from bs4 import Tag
+
 from colusa.etr import Extractor, register_extractor
 
 
 @register_extractor('//agilethought.com')
 class AgileThoughtExtractor(Extractor):
-    def _find_main_content(self):
-        self.site = self.bs.find('div', attrs={'data-elementor-type': 'single'})
+    def _find_main_content(self) -> Tag:
+        return self.bs.find('div', attrs={'data-elementor-type': 'single'})
 
     def cleanup(self):
-        first_div = self.site.find('div', class_="elementor-section-wrap")
+        first_div = self.main_content.find('div', class_="elementor-section-wrap")
         if first_div is None:
             super(Extractor, self).cleanup()
             return

--- a/colusa/plugins/etr_agilethought.py
+++ b/colusa/plugins/etr_agilethought.py
@@ -3,7 +3,7 @@ from colusa.etr import Extractor, register_extractor
 
 @register_extractor('//agilethought.com')
 class AgileThoughtExtractor(Extractor):
-    def internal_init(self):
+    def _find_main_content(self):
         self.site = self.bs.find('div', attrs={'data-elementor-type': 'single'})
 
     def cleanup(self):
@@ -24,13 +24,13 @@ class AgileThoughtExtractor(Extractor):
         for section in to_removed:
             section.extract()
 
-    def get_author(self):
+    def _parse_author(self):
         yoast_data = self.bs.find('script', attrs={
             'type': "application/ld+json",
             'class': "yoast-schema-graph",
         })
         if yoast_data is None:
-            return super(AgileThoughtExtractor, self).get_author()
+            return super(AgileThoughtExtractor, self)._parse_author()
         import json
         data = json.loads(yoast_data.string)
         graph = data.get('@graph', [])

--- a/colusa/plugins/etr_avikdas.py
+++ b/colusa/plugins/etr_avikdas.py
@@ -4,8 +4,8 @@ from colusa.etr import Extractor, register_extractor
 @register_extractor('avikdas.com')
 class AvikdasExtractor(Extractor):
     def _find_main_content(self):
-        self.site = self.bs.body
+        return self.bs.body
 
     def cleanup(self):
-        self.remove_tag(self.site, 'ul', attrs={'id': 'bottom-links'})
-        self.remove_tag(self.site, 'h1', attrs={})
+        self.remove_tag(self.main_content, 'ul', attrs={'id': 'bottom-links'})
+        self.remove_tag(self.main_content, 'h1', attrs={})

--- a/colusa/plugins/etr_avikdas.py
+++ b/colusa/plugins/etr_avikdas.py
@@ -3,7 +3,7 @@ from colusa.etr import Extractor, register_extractor
 
 @register_extractor('avikdas.com')
 class AvikdasExtractor(Extractor):
-    def internal_init(self):
+    def _find_main_content(self):
         self.site = self.bs.body
 
     def cleanup(self):

--- a/colusa/plugins/etr_cadenceworkflow.py
+++ b/colusa/plugins/etr_cadenceworkflow.py
@@ -3,5 +3,5 @@ from colusa.etr import Extractor, register_extractor
 
 @register_extractor('https://cadenceworkflow.io')
 class CadenceWorkflowExtractor(Extractor):
-    def internal_init(self):
+    def _find_main_content(self):
         self.site = self.bs.find('main')

--- a/colusa/plugins/etr_cadenceworkflow.py
+++ b/colusa/plugins/etr_cadenceworkflow.py
@@ -4,4 +4,4 @@ from colusa.etr import Extractor, register_extractor
 @register_extractor('https://cadenceworkflow.io')
 class CadenceWorkflowExtractor(Extractor):
     def _find_main_content(self):
-        self.site = self.bs.find('main')
+        return self.bs.find('main')

--- a/colusa/plugins/etr_cs_rutgers_edu.py
+++ b/colusa/plugins/etr_cs_rutgers_edu.py
@@ -3,7 +3,7 @@ from colusa.etr import Extractor, register_extractor
 
 @register_extractor('www.cs.rutgers.edu/~pxk/')
 class CSRutgersEduExtractor(Extractor):
-    def internal_init(self):
+    def _find_main_content(self):
         self.site = self.bs.find('div', attrs={'id': 'main'})
 
     def cleanup(self):

--- a/colusa/plugins/etr_cs_rutgers_edu.py
+++ b/colusa/plugins/etr_cs_rutgers_edu.py
@@ -4,9 +4,9 @@ from colusa.etr import Extractor, register_extractor
 @register_extractor('www.cs.rutgers.edu/~pxk/')
 class CSRutgersEduExtractor(Extractor):
     def _find_main_content(self):
-        self.site = self.bs.find('div', attrs={'id': 'main'})
+        return self.bs.find('div', attrs={'id': 'main'})
 
     def cleanup(self):
-        self.remove_tag(self.site, 'div', attrs={'id': 'downloadmsg'})
-        self.remove_tag(self.site, 'div', attrs={'id': 'headline'})
+        self.remove_tag(self.main_content, 'div', attrs={'id': 'downloadmsg'})
+        self.remove_tag(self.main_content, 'div', attrs={'id': 'headline'})
         super(CSRutgersEduExtractor, self).cleanup()

--- a/colusa/plugins/etr_engineering_sportify.py
+++ b/colusa/plugins/etr_engineering_sportify.py
@@ -4,5 +4,5 @@ from colusa.etr import Extractor, register_extractor
 @register_extractor('engineering.atspotify.com')
 class EngineeringSpotifyExtractor(Extractor):
     def cleanup(self):
-        self.remove_tag(self.site, 'div', attrs={'class': 'share-block'})
+        self.remove_tag(self.main_content, 'div', attrs={'class': 'share-block'})
         super(EngineeringSpotifyExtractor, self).cleanup()

--- a/colusa/plugins/etr_fsblog.py
+++ b/colusa/plugins/etr_fsblog.py
@@ -3,12 +3,12 @@ from colusa.etr import Extractor, register_extractor
 
 @register_extractor('fs.blog')
 class FsblogExtractor(Extractor):
-    def get_title(self):
+    def _parse_title(self):
         h1 = self.bs.find('h1', class_='entry-title')
         return h1.text
 
     def cleanup(self):
-        self.remove_tag(self.site, 'p', attrs={
+        self.remove_tag(self.main_content, 'p', attrs={
             'style': 'color: black; background: #ffffcc none repeat scroll 0% 0%; text-align: center;'
         })
         super(FsblogExtractor, self).cleanup()

--- a/colusa/plugins/etr_hbr.py
+++ b/colusa/plugins/etr_hbr.py
@@ -8,11 +8,11 @@ from colusa.etr import Extractor, Transformer, register_extractor, register_tran
 @register_extractor('//hbr.org')
 class HBRExtractor(Extractor):
     def _find_main_content(self):
-        self.site = self.bs.find('div', class_='article-body standard-content')
+        return self.bs.find('div', class_='article-body standard-content')
 
     def cleanup(self):
-        self.remove_tag(self.site, 'div', attrs={'class': 'left-rail--container'})
-        self.remove_tag(self.site, 'div', attrs={'class': 'translate-message'})
-        self.remove_tag(self.site, 'div', attrs={'class': 'right-rail--container'})
-        self.remove_tag(self.site, 'div', attrs={'class': 'post-container'})
+        self.remove_tag(self.main_content, 'div', attrs={'class': 'left-rail--container'})
+        self.remove_tag(self.main_content, 'div', attrs={'class': 'translate-message'})
+        self.remove_tag(self.main_content, 'div', attrs={'class': 'right-rail--container'})
+        self.remove_tag(self.main_content, 'div', attrs={'class': 'post-container'})
 

--- a/colusa/plugins/etr_hbr.py
+++ b/colusa/plugins/etr_hbr.py
@@ -7,7 +7,7 @@ from colusa.etr import Extractor, Transformer, register_extractor, register_tran
 
 @register_extractor('//hbr.org')
 class HBRExtractor(Extractor):
-    def internal_init(self):
+    def _find_main_content(self):
         self.site = self.bs.find('div', class_='article-body standard-content')
 
     def cleanup(self):

--- a/colusa/plugins/etr_increment.py
+++ b/colusa/plugins/etr_increment.py
@@ -3,14 +3,14 @@ from colusa.etr import Extractor, register_extractor
 
 @register_extractor('//increment.com')
 class IncrementDotComExtractor(Extractor):
-    def get_title(self):
+    def _parse_title(self):
         title = self.bs.find('h1', class_='t-TitleSerif large title')
         return title.text
 
-    def internal_init(self):
+    def _find_main_content(self):
         self.site = self.bs.find('article', attrs={'itemprop': 'articleBody'})
 
-    def get_metadata(self):
+    def _parse_extra_metadata(self):
         author_tag = self.bs.find('a', attrs={'itemprop': 'author'})
         if author_tag is None:
             author = ''

--- a/colusa/plugins/etr_increment.py
+++ b/colusa/plugins/etr_increment.py
@@ -8,7 +8,7 @@ class IncrementDotComExtractor(Extractor):
         return title.text
 
     def _find_main_content(self):
-        self.site = self.bs.find('article', attrs={'itemprop': 'articleBody'})
+        return self.bs.find('article', attrs={'itemprop': 'articleBody'})
 
     def _parse_extra_metadata(self):
         author_tag = self.bs.find('a', attrs={'itemprop': 'author'})

--- a/colusa/plugins/etr_infoq.py
+++ b/colusa/plugins/etr_infoq.py
@@ -3,7 +3,7 @@ from colusa.etr import Extractor, register_extractor
 
 @register_extractor('//www.infoq.com')
 class InfoQExtractor(Extractor):
-    def internal_init(self):
+    def _find_main_content(self):
         self.site = self.bs.find('div', class_='article__content')
 
     def cleanup(self):

--- a/colusa/plugins/etr_infoq.py
+++ b/colusa/plugins/etr_infoq.py
@@ -4,10 +4,10 @@ from colusa.etr import Extractor, register_extractor
 @register_extractor('//www.infoq.com')
 class InfoQExtractor(Extractor):
     def _find_main_content(self):
-        self.site = self.bs.find('div', class_='article__content')
+        return self.bs.find('div', class_='article__content')
 
     def cleanup(self):
-        self.remove_tag(self.site, 'div', attrs={'class': 'contentRatingWidget'})
-        self.remove_tag(self.site, 'div', attrs={'class': 'widget article__fromTopic topics'})
-        self.remove_tag(self.site, 'div', attrs={'class': 'nocontent'})
+        self.remove_tag(self.main_content, 'div', attrs={'class': 'contentRatingWidget'})
+        self.remove_tag(self.main_content, 'div', attrs={'class': 'widget article__fromTopic topics'})
+        self.remove_tag(self.main_content, 'div', attrs={'class': 'nocontent'})
         super(InfoQExtractor, self).cleanup()

--- a/colusa/plugins/etr_knowledgegraph.py
+++ b/colusa/plugins/etr_knowledgegraph.py
@@ -4,8 +4,9 @@ from colusa.etr import Extractor, register_extractor
 @register_extractor('//knowledgegraph.today')
 class KnowledgegraphTodayExtractor(Extractor):
     def _find_main_content(self):
-        self.site = self.bs.body
+        return self.bs.body
 
     def _parse_title(self):
-        p_title = self.site.find('p', class_='title')
+        # TODO: self.main_content here might not be available, need to find other way
+        p_title = self.main_content.find('p', class_='title')
         return p_title.text

--- a/colusa/plugins/etr_knowledgegraph.py
+++ b/colusa/plugins/etr_knowledgegraph.py
@@ -3,9 +3,9 @@ from colusa.etr import Extractor, register_extractor
 
 @register_extractor('//knowledgegraph.today')
 class KnowledgegraphTodayExtractor(Extractor):
-    def internal_init(self):
+    def _find_main_content(self):
         self.site = self.bs.body
 
-    def get_title(self):
+    def _parse_title(self):
         p_title = self.site.find('p', class_='title')
         return p_title.text

--- a/colusa/plugins/etr_medium.py
+++ b/colusa/plugins/etr_medium.py
@@ -15,7 +15,7 @@ class MediumExtractor(Extractor):
         return self.bs.title.text
 
     def _find_main_content(self):
-        self.site = self.bs.find('article')
+        return self.bs.find('article')
 
 
 @register_transformer('//medium.com')

--- a/colusa/plugins/etr_medium.py
+++ b/colusa/plugins/etr_medium.py
@@ -6,7 +6,7 @@ from colusa.etr import Extractor, Transformer, register_extractor, register_tran
 @register_extractor('//medium.com')
 class MediumExtractor(Extractor):
     def _parse_title(self):
-        title = self.site.find('h1')
+        title = self.main_content.find('h1')
         if title is not None:
             return title.text
         meta = self.bs.find('meta', attrs={'property': 'og:title'})

--- a/colusa/plugins/etr_medium.py
+++ b/colusa/plugins/etr_medium.py
@@ -5,7 +5,7 @@ from colusa.etr import Extractor, Transformer, register_extractor, register_tran
 
 @register_extractor('//medium.com')
 class MediumExtractor(Extractor):
-    def get_title(self):
+    def _parse_title(self):
         title = self.site.find('h1')
         if title is not None:
             return title.text
@@ -14,7 +14,7 @@ class MediumExtractor(Extractor):
             return meta.get('content')
         return self.bs.title.text
 
-    def internal_init(self):
+    def _find_main_content(self):
         self.site = self.bs.find('article')
 
 

--- a/colusa/plugins/etr_morning.py
+++ b/colusa/plugins/etr_morning.py
@@ -3,7 +3,7 @@ from colusa.etr import Extractor, register_extractor
 
 @register_extractor('//blog.acolyer.org')
 class TheMorningPaperExtractor(Extractor):
-    def get_title(self):
+    def _parse_title(self):
         header = self.bs.find('h1', class_='entry-title')
         return header.text
 

--- a/colusa/plugins/etr_preethikasireddy.py
+++ b/colusa/plugins/etr_preethikasireddy.py
@@ -4,4 +4,4 @@ from colusa.etr import Extractor, register_extractor
 @register_extractor('//www.preethikasireddy.com')
 class PreethikasireddyExtractor(Extractor):
     def _find_main_content(self):
-        self.site = self.bs.find('div', attrs={'id': 'Story'})
+        return self.bs.find('div', attrs={'id': 'Story'})

--- a/colusa/plugins/etr_preethikasireddy.py
+++ b/colusa/plugins/etr_preethikasireddy.py
@@ -3,5 +3,5 @@ from colusa.etr import Extractor, register_extractor
 
 @register_extractor('//www.preethikasireddy.com')
 class PreethikasireddyExtractor(Extractor):
-    def internal_init(self):
+    def _find_main_content(self):
         self.site = self.bs.find('div', attrs={'id': 'Story'})

--- a/colusa/plugins/etr_scrumcrazy.py
+++ b/colusa/plugins/etr_scrumcrazy.py
@@ -7,22 +7,22 @@ class ScrumCrazyExtractor(Extractor):
         self.author = None
         super(ScrumCrazyExtractor, self).__init__(bs)
 
-    def get_author(self):
+    def _parse_author(self):
         if self.author:
             return self.author
         else:
-            return super(ScrumCrazyExtractor, self).get_author()
+            return super(ScrumCrazyExtractor, self)._parse_author()
 
-    def internal_init(self):
-        super(ScrumCrazyExtractor, self).internal_init()
-        post_info_div = self.site.find('div', class_='postinfo')
+    def _find_main_content(self):
+        super(ScrumCrazyExtractor, self)._find_main_content()
+        post_info_div = self.main_content.find('div', class_='postinfo')
         if post_info_div is not None:
             post_info = post_info_div.text.strip()
             import re
             m = re.search(r'by (.*)$', post_info)
             if m is not None:
                 self.author = m.group(1)
-        entry = self.site.find('div', class_='entry')
+        entry = self.main_content.find('div', class_='entry')
         if entry is not None:
             self.site = entry
 

--- a/colusa/plugins/etr_scrumcrazy.py
+++ b/colusa/plugins/etr_scrumcrazy.py
@@ -3,29 +3,21 @@ from colusa.etr import Extractor, register_extractor
 
 @register_extractor('//scrumcrazy.wordpress.com')
 class ScrumCrazyExtractor(Extractor):
-    def __init__(self, bs):
-        self.author = None
-        super(ScrumCrazyExtractor, self).__init__(bs)
-
-    def _parse_author(self):
-        if self.author:
-            return self.author
-        else:
-            return super(ScrumCrazyExtractor, self)._parse_author()
-
     def _find_main_content(self):
-        super(ScrumCrazyExtractor, self)._find_main_content()
-        post_info_div = self.main_content.find('div', class_='postinfo')
+        possible_main = super(ScrumCrazyExtractor, self)._find_main_content()
+        post_info_div = possible_main.find('div', class_='postinfo')
         if post_info_div is not None:
             post_info = post_info_div.text.strip()
             import re
             m = re.search(r'by (.*)$', post_info)
             if m is not None:
                 self.author = m.group(1)
-        entry = self.main_content.find('div', class_='entry')
+        entry = possible_main.find('div', class_='entry')
         if entry is not None:
-            self.site = entry
+            return entry
+        else:
+            return possible_main
 
     def cleanup(self):
-        self.remove_tag(self.site, 'div', attrs={'id': 'jp-post-flair'})
-        self.remove_tag(self.site, 'p', attrs={'class': 'postinfo'})
+        self.remove_tag(self.main_content, 'div', attrs={'id': 'jp-post-flair'})
+        self.remove_tag(self.main_content, 'p', attrs={'class': 'postinfo'})

--- a/colusa/plugins/etr_scrumcrazy.py
+++ b/colusa/plugins/etr_scrumcrazy.py
@@ -3,6 +3,15 @@ from colusa.etr import Extractor, register_extractor
 
 @register_extractor('//scrumcrazy.wordpress.com')
 class ScrumCrazyExtractor(Extractor):
+    def __init__(self, bs):
+        self._cached_author = None
+        super(ScrumCrazyExtractor, self).__init__(bs)
+
+    def _parse_author(self) -> str:
+        if self._cached_author:
+            return self._cached_author
+        return super(ScrumCrazyExtractor, self)._parse_author()
+
     def _find_main_content(self):
         possible_main = super(ScrumCrazyExtractor, self)._find_main_content()
         post_info_div = possible_main.find('div', class_='postinfo')
@@ -11,7 +20,7 @@ class ScrumCrazyExtractor(Extractor):
             import re
             m = re.search(r'by (.*)$', post_info)
             if m is not None:
-                self.author = m.group(1)
+                self._cached_author = m.group(1)
         entry = possible_main.find('div', class_='entry')
         if entry is not None:
             return entry

--- a/colusa/plugins/etr_sed.py
+++ b/colusa/plugins/etr_sed.py
@@ -3,5 +3,5 @@ from colusa.etr import Extractor, register_extractor
 
 @register_extractor('https://softwareengineeringdaily.com/')
 class SoftwareEngineeringDailyExtractor(Extractor):
-    def internal_init(self):
+    def _find_main_content(self):
         self.site = self.bs.find('main')

--- a/colusa/plugins/etr_sed.py
+++ b/colusa/plugins/etr_sed.py
@@ -4,4 +4,4 @@ from colusa.etr import Extractor, register_extractor
 @register_extractor('https://softwareengineeringdaily.com/')
 class SoftwareEngineeringDailyExtractor(Extractor):
     def _find_main_content(self):
-        self.site = self.bs.find('main')
+        return self.bs.find('main')

--- a/colusa/plugins/etr_slack_engineering.py
+++ b/colusa/plugins/etr_slack_engineering.py
@@ -3,9 +3,9 @@ from colusa.etr import Extractor, register_extractor
 
 @register_extractor('//slack.engineering')
 class SlackEngineeringExtractor(Extractor):
-    def get_title(self):
+    def _parse_title(self):
         title = self.bs.find('h1')
         return title.text
 
-    def internal_init(self):
+    def _find_main_content(self):
         self.site = self.bs.find(id='primary', class_='main-content')

--- a/colusa/plugins/etr_slack_engineering.py
+++ b/colusa/plugins/etr_slack_engineering.py
@@ -8,4 +8,4 @@ class SlackEngineeringExtractor(Extractor):
         return title.text
 
     def _find_main_content(self):
-        self.site = self.bs.find(id='primary', class_='main-content')
+        return self.bs.find(id='primary', class_='main-content')

--- a/colusa/plugins/etr_staffeng.py
+++ b/colusa/plugins/etr_staffeng.py
@@ -4,4 +4,4 @@ from colusa.etr import Extractor, register_extractor
 @register_extractor('//staffeng.com')
 class StaffEng(Extractor):
     def _find_main_content(self):
-        self.site = self.bs.find(class_='blog-post-content')
+        return self.bs.find(class_='blog-post-content')

--- a/colusa/plugins/etr_staffeng.py
+++ b/colusa/plugins/etr_staffeng.py
@@ -3,5 +3,5 @@ from colusa.etr import Extractor, register_extractor
 
 @register_extractor('//staffeng.com')
 class StaffEng(Extractor):
-    def internal_init(self):
+    def _find_main_content(self):
         self.site = self.bs.find(class_='blog-post-content')

--- a/colusa/plugins/etr_trivago.py
+++ b/colusa/plugins/etr_trivago.py
@@ -7,10 +7,10 @@ class TrivagoExtractor(Extractor):
         super(TrivagoExtractor, self).__init__(bs)
         self.title = ''
 
-    def get_title(self):
+    def _parse_title(self):
         return self.title
 
-    def get_author(self):
+    def _parse_author(self):
         meta = self.bs.find_all('meta', attrs={'name': 'author'})
         for a in meta:
             value = a.get('content')
@@ -20,5 +20,5 @@ class TrivagoExtractor(Extractor):
         return None
 
     def cleanup(self):
-        self.title = self.site.find('header', class_='post__header').find('h1').text
-        self.remove_tag(self.site, 'header', attrs={'class': 'post__header'})
+        self.title = self.main_content.find('header', class_='post__header').find('h1').text
+        self.remove_tag(self.main_content, 'header', attrs={'class': 'post__header'})

--- a/colusa/plugins/etr_truyenfull.py
+++ b/colusa/plugins/etr_truyenfull.py
@@ -7,7 +7,7 @@ from colusa.etr import Extractor, Transformer, register_extractor, register_tran
 
 @register_extractor('//truyenfull.vn')
 class TruyenFullExtractor(Extractor):
-    def internal_init(self):
+    def _find_main_content(self):
         self.site = self.bs.find('div', id='chapter-big-container')
 
     def cleanup(self):

--- a/colusa/plugins/etr_truyenfull.py
+++ b/colusa/plugins/etr_truyenfull.py
@@ -8,13 +8,13 @@ from colusa.etr import Extractor, Transformer, register_extractor, register_tran
 @register_extractor('//truyenfull.vn')
 class TruyenFullExtractor(Extractor):
     def _find_main_content(self):
-        self.site = self.bs.find('div', id='chapter-big-container')
+        return self.bs.find('div', id='chapter-big-container')
 
     def cleanup(self):
-        self.remove_tag(self.site, 'div', attrs={'id': 'chapter-nav-top'})
-        self.remove_tag(self.site, 'div', attrs={'id': 'chapter-nav-bot'})
-        self.remove_tag(self.site, 'a', attrs={'class': 'truyen-title'})
-        self.remove_tag(self.site, 'h2', attrs={})
+        self.remove_tag(self.main_content, 'div', attrs={'id': 'chapter-nav-top'})
+        self.remove_tag(self.main_content, 'div', attrs={'id': 'chapter-nav-bot'})
+        self.remove_tag(self.main_content, 'a', attrs={'class': 'truyen-title'})
+        self.remove_tag(self.main_content, 'h2', attrs={})
 
 
 @register_transformer('//truyenfull.vn')

--- a/colusa/plugins/etr_unintendedconsequences.py
+++ b/colusa/plugins/etr_unintendedconsequences.py
@@ -3,10 +3,10 @@ from colusa.etr import Extractor, register_extractor
 
 @register_extractor('unintendedconsequenc')
 class UnintendedConsequencesExtractor(Extractor):
-    def get_title(self):
+    def _parse_title(self):
         return self.bs.find('h1').text
 
-    def internal_init(self):
+    def _find_main_content(self):
         self.site = self.bs.find(id='page')
 
     def get_content(self):

--- a/colusa/plugins/etr_unintendedconsequences.py
+++ b/colusa/plugins/etr_unintendedconsequences.py
@@ -7,7 +7,7 @@ class UnintendedConsequencesExtractor(Extractor):
         return self.bs.find('h1').text
 
     def _find_main_content(self):
-        self.site = self.bs.find(id='page')
+        return self.bs.find(id='page')
 
     def get_content(self):
-        return self.site.find(attrs={'class': 'entry-content'})
+        return self.main_content.find(attrs={'class': 'entry-content'})

--- a/colusa/plugins/etr_untools.py
+++ b/colusa/plugins/etr_untools.py
@@ -20,4 +20,4 @@ class UntoolsExtractor(Extractor):
         return f'.{tag}\n****\n{usage}\n****\n\n'
 
     def _find_main_content(self):
-        self.site = self.bs.find(class_=re.compile('article-module--content--'))
+        return self.bs.find(class_=re.compile('article-module--content--'))

--- a/colusa/plugins/etr_untools.py
+++ b/colusa/plugins/etr_untools.py
@@ -5,13 +5,13 @@ from colusa.etr import Extractor, register_extractor
 
 @register_extractor('//untools.co')
 class UntoolsExtractor(Extractor):
-    def get_title(self):
+    def _parse_title(self):
         import re
         header = self.bs.find('div', class_=re.compile('article-module--top--'))
         title = header.find('h2').text
         return title
 
-    def get_metadata(self):
+    def _parse_extra_metadata(self):
         import re
         header = self.bs.find('div', class_=re.compile('article-module--top--'))
         tag = header.find('span', class_=re.compile('tag-module--tag--')).text
@@ -19,5 +19,5 @@ class UntoolsExtractor(Extractor):
 
         return f'.{tag}\n****\n{usage}\n****\n\n'
 
-    def internal_init(self):
+    def _find_main_content(self):
         self.site = self.bs.find(class_=re.compile('article-module--content--'))

--- a/colusa/plugins/etr_wikipedia.py
+++ b/colusa/plugins/etr_wikipedia.py
@@ -8,4 +8,4 @@ class WikipediaExtractor(Extractor):
         return title.text
 
     def _find_main_content(self):
-        self.site = self.bs.find(id='bodyContent')
+        return self.bs.find(id='bodyContent')

--- a/colusa/plugins/etr_wikipedia.py
+++ b/colusa/plugins/etr_wikipedia.py
@@ -3,9 +3,9 @@ from colusa.etr import Extractor, register_extractor
 
 @register_extractor('.wikipedia.org/')
 class WikipediaExtractor(Extractor):
-    def get_title(self):
+    def _parse_title(self):
         title = self.bs.find('h1', id='firstHeading')
         return title.text
 
-    def internal_init(self):
+    def _find_main_content(self):
         self.site = self.bs.find(id='bodyContent')

--- a/colusa/plugins/etr_xp123.py
+++ b/colusa/plugins/etr_xp123.py
@@ -8,7 +8,7 @@ class XP123Extractor(Extractor):
         self.published = None
         super(XP123Extractor, self).__init__(bs)
 
-    def internal_init(self):
+    def _find_main_content(self):
         self.site = self.bs.find('article', attrs={'class': 'post'})
 
     def cleanup(self):
@@ -16,10 +16,10 @@ class XP123Extractor(Extractor):
         self.remove_tag(self.site, 'section', attrs={'class': 'yikes-mailchimp-container'})
         self.remove_tag(self.site, 'footer', attrs={'class': 'entry-meta'})
 
-    def get_author(self):
-        return self.author if self.author else super(XP123Extractor, self).get_author()
+    def _parse_author(self):
+        return self.author if self.author else super(XP123Extractor, self)._parse_author()
 
-    def get_published(self):
-        return self.published if self.published else super(XP123Extractor, self).get_published()
+    def _parse_published(self):
+        return self.published if self.published else super(XP123Extractor, self)._parse_published()
 
 

--- a/colusa/plugins/etr_xp123.py
+++ b/colusa/plugins/etr_xp123.py
@@ -8,8 +8,6 @@ class XP123Extractor(Extractor):
         self.published = None
         super(XP123Extractor, self).__init__(bs)
 
-        self._parse_yoast()
-
     def internal_init(self):
         self.site = self.bs.find('article', attrs={'class': 'post'})
 
@@ -24,33 +22,4 @@ class XP123Extractor(Extractor):
     def get_published(self):
         return self.published if self.published else super(XP123Extractor, self).get_published()
 
-    def _parse_yoast(self):
-        yoast_data = self.bs.find('script', attrs={
-            'type': "application/ld+json",
-            'class': "yoast-schema-graph",
-        })
-        if yoast_data is None:
-            return
-
-        import json
-        from dateutil import parser
-        data = json.loads(yoast_data.string)
-        graph = data.get('@graph', [])
-        persons = {}
-        author = None
-        for g in graph:
-            g_type = g.get('@type', '')
-            if g_type == 'Article':
-                author = g.get('author', {}).get('@id')
-                published_value = g.get('datePublished')
-                if published_value:
-                    published = parser.parse(published_value)
-                    self.published = str(published.date())
-
-            if (type(g_type) is list and 'Person' in g_type) or (type(g_type) is str and g_type == 'Person'):
-                person_id = g.get('@id', '')
-                person_name = g.get('name', '')
-                persons[person_id] = person_name
-        if author in persons:
-            self.author = persons[author]
 

--- a/colusa/plugins/etr_xp123.py
+++ b/colusa/plugins/etr_xp123.py
@@ -3,23 +3,10 @@ from colusa.etr import Extractor, register_extractor
 
 @register_extractor('//xp123.com')
 class XP123Extractor(Extractor):
-    def __init__(self, bs):
-        self.author = None
-        self.published = None
-        super(XP123Extractor, self).__init__(bs)
-
     def _find_main_content(self):
-        self.site = self.bs.find('article', attrs={'class': 'post'})
+        return self.bs.find('article', attrs={'class': 'post'})
 
     def cleanup(self):
-        self.remove_tag(self.site, 'header', attrs={'class': 'entry-header'})
-        self.remove_tag(self.site, 'section', attrs={'class': 'yikes-mailchimp-container'})
-        self.remove_tag(self.site, 'footer', attrs={'class': 'entry-meta'})
-
-    def _parse_author(self):
-        return self.author if self.author else super(XP123Extractor, self)._parse_author()
-
-    def _parse_published(self):
-        return self.published if self.published else super(XP123Extractor, self)._parse_published()
-
-
+        self.remove_tag(self.main_content, 'header', attrs={'class': 'entry-header'})
+        self.remove_tag(self.main_content, 'section', attrs={'class': 'yikes-mailchimp-container'})
+        self.remove_tag(self.main_content, 'footer', attrs={'class': 'entry-meta'})


### PR DESCRIPTION
Extractor's parsing metadata is not explicitly happens in the right order. Therefore causing some confusing when implement the parsers in plugins.

This PR proposes a order to find main content of a website and then parse metadata