### PR TITLE
chg: ability to name the generated book instead of default index.asciidoc

### DIFF
--- a/src/colusa/colusa.py
+++ b/src/colusa/colusa.py
@@ -32,6 +32,7 @@ class Colusa(object):
             "version": "v1.0",
             "homepage": "__fill url to home page__",
             "output_dir": "__fill output dir__",
+            "book_file_name": "index.asciidoc",
             "multi_part": False,
             "metadata": True,
             "make": {

--- a/src/colusa/etr.py
+++ b/src/colusa/etr.py
@@ -379,17 +379,21 @@ class Render(object):
         return article_metadata
 
     def generate_makefile(self, make_params: dict):
+        book_file_name = self.config.get('book_file_name', 'index.asciidoc')
+        target_prefix = book_file_name
+        target_prefix = target_prefix.removesuffix('.asciidoc').replace('-', '_')
+        target_prefix = '' if target_prefix == 'index' else f'{target_prefix}_'
         template = f'''html:
-\tasciidoctor index.asciidoc -d book -b html5 -D output {make_params.get('html', '')}
+\tasciidoctor {book_file_name} -d book -b html5 -D output {make_params.get('html', '')}
 \tcp -r images output/
 
 epub:
-\tasciidoctor-epub3 index.asciidoc -d book -D output {make_params.get('epub', '')}
+\tasciidoctor-epub3 {book_file_name} -d book -D output {make_params.get('epub', '')}
 
 pdf:
-\tasciidoctor-pdf index.asciidoc -d book -D output {make_params.get('pdf', '')}
+\tasciidoctor-pdf {book_file_name} -d book -D output {make_params.get('pdf', '')}
 '''
-        file_path = os.path.join(self.output_dir, 'Makefile')
+        file_path = os.path.join(self.output_dir, f'{target_prefix}Makefile')
         with open(file_path, 'w') as out_file:
             out_file.write(template)
 
@@ -415,7 +419,8 @@ pdf:
 
 {included_files}
 '''
-        with open(os.path.join(self.output_dir, 'index.asciidoc'), 'w') as index_file:
+        book_file_name = self.config.get('book_file_name', 'index.asciidoc')
+        with open(os.path.join(self.output_dir, book_file_name), 'w') as index_file:
             index_file.write(content)
 
 


### PR DESCRIPTION
Add new setting `book_file_name`, default value is `index.asciidoc` to specify file name of generated book

Requires:

* book_file_name ending with `.asciidoc`

If `book_file_name` is different from `index.asciidoc` then the generated Makefile will be `basename{book_file_name}_Makefile` and to generate book, run command `make -f newmakefile pdf`