### PR TITLE
chg: allow external configuration for extractors, transformers

### DIFF
--- a/src/colusa/colusa.py
+++ b/src/colusa/colusa.py
@@ -12,11 +12,15 @@ class Colusa(object):
     Implementation for initializing book configuration and generating book from configuration
     """
     def __init__(self, configuration: dict):
+        from colusa.etr import populate_extractor_config, populate_transformer_config
+
         utils.scan('colusa.plugins')
         self.config = configuration
         self.output_dir = configuration.get('output_dir', '.')
         self.book_maker = etr.Render(configuration)
         self.downloader = fetch.Downloader(configuration.get('downloader', {}))
+        populate_extractor_config(configuration.get('extractors', {}))
+        populate_transformer_config(configuration.get('transformers', {}))
 
     @classmethod
     def generate_new_configuration(cls, file_path: str):

--- a/src/colusa/plugins/etr_pragmatic_engineer.py
+++ b/src/colusa/plugins/etr_pragmatic_engineer.py
@@ -1,4 +1,4 @@
-from colusa.etr import Extractor, Transformer, register_extractor, register_transformer
+from colusa.etr import Extractor, Transformer, register_extractor_v2, register_transformer_v2
 from colusa.asciidoc_visitor import AsciidocVisitor
 from bs4 import Tag
 import re
@@ -7,7 +7,7 @@ import requests
 import json
 
 
-@register_extractor('//newsletter.pragmaticengineer.com|learnings.aleixmorgadas.dev')
+@register_extractor_v2('substack', '//newsletter.pragmaticengineer.com|learnings.aleixmorgadas.dev')
 class PragmaticEngineerExtractor(Extractor):
     def cleanup(self):
         self.remove_tag(self.main_content, 'div', attrs={'class': 'subscribe-widget'})
@@ -103,7 +103,7 @@ class PEAsciidocVisitor(AsciidocVisitor):
     visit_tag_h4 = visit_heading_node(4)
 
 
-@register_transformer('//newsletter.pragmaticengineer.com|learnings.aleixmorgadas.dev')
+@register_transformer_v2('substack', '//newsletter.pragmaticengineer.com|learnings.aleixmorgadas.dev')
 class PragmaticEngineerTransformer(Transformer):
     def create_visitor(self):
         return PEAsciidocVisitor()


### PR DESCRIPTION
This change allows end-user to specify which extractor/transformer to be used for given url. 
Previously, the url patterns are hard code into plugin (extractor/transformer). Which make it very hard to adapt to multiple blog sites, such as blogs from substack.
Now users can specify in the configuration file.